### PR TITLE
Documentation updates, direct JWT refresh

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,18 +56,40 @@ root.render(
 );
 ```
 
+### Server Code Requirements
+
+Authenticating with FusionAuth requires you to set up a server that will be used to perform
+the OAuth token exchange. See the [server requirements]()
+
 ## Usage
 
 ### Pre-built buttons
-There are three buttons that are configured to perform login/logout/registration: `FusionAuthLoginButton`, `FusionAuthLogoutButton`, and `FusionAuthRegisterButton`.
-These can be placed anywhere in your app as-is.
+There are three pre-styled buttons that are configured to perform login/logout/registration. They can be placed anywhere in your app as is.
 
 ```TSX
-import {FusionAuthLoginButton, FusionAuthLogoutButton, FusionAuthRegisterButton} from 'fusionauth-react-sdk';
+import {
+    FusionAuthLoginButton,
+    FusionAuthLogoutButton,
+    FusionAuthRegisterButton
+} from 'fusionauth-react-sdk';
 
-<FusionAuthLoginButton />
-<FusionAuthRegisterButton />
-<FusionAuthLogoutButton />
+export const LoginPage = () => (
+    <>
+        <h1>Welcome, please log in or register</h1>
+
+        <FusionAuthLoginButton />
+
+        <FusionAuthRegisterButton />
+    </>
+);
+
+export const AccountPage = () => (
+    <>
+        <h1>Hello, user!</h1>
+
+        <FusionAuthLogoutButton />
+    </>
+);
 ```
 
 ### Programmatic usage
@@ -146,7 +168,7 @@ const AdminPanel = () => (
 
 ## Example App
 
-See the [FusionAuth React SDK Example]() for functional example of a React client that utilizes the SDK
+See the [FusionAuth React SDK Example](https://github.com/FusionAuth/fusionauth-react-sdk-example) for functional example of a React client that utilizes the SDK
 as well as an Express server that performs the token exchange.
 
 ## Documentation

--- a/docs/functions.md
+++ b/docs/functions.md
@@ -2,7 +2,7 @@
 
 ## useFusionAuth
 
-A hook that returns an object containing the [FusionAuthContext](FusionAuthProvider.md#fusionauthcontext)
+A hook that returns an object containing the [FusionAuthContext](context.md#fusionauthcontext)
 
 #### Properties
 
@@ -18,7 +18,7 @@ A hook that returns an object containing the [FusionAuthContext](FusionAuthProvi
 
 ## withFusionAuth
 
-A higher-order component used to give components access to the [FusionAuthContext](#fusionauthcontext).
+A higher-order component used to give components access to the [FusionAuthContext](context.md#fusionauthcontext).
 
 #### Arguments
 


### PR DESCRIPTION
## What is this PR and why do we need it?

_This work updates the documentation with more clear usage/examples, and refactors the JWT refresh to go directly to FusionAuth rather than through the server._

#### Pre-Merge Checklist (if applicable)

-   [ ] Unit and Feature tests have been added/updated for logic changes, or there is a justifiable reason for not doing so.
