### PR TITLE
Add call to new /logout endpoint to clear tokens

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -4,3 +4,4 @@ coverage
 node_modules
 README.md
 src/**/*.min.css
+.github/ISSUE_TEMPLATE/*.md

--- a/README.adoc
+++ b/README.adoc
@@ -323,7 +323,7 @@ To perform a release:
 
 * Pull the code to your local machine
 * Bump the version in `package.json`
-* Run `npm webpack`
+* Run `npm run webpack`
 * Run `npm publish`
 
 You may have to set up your machine to be able to publish, which will

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fusionauth-react-sdk",
-  "version": "0.22.0",
+  "version": "0.22.1",
   "description": "FusionAuth solves the problem of building essential security without adding risk or distracting from your primary application",
   "scripts": {
     "webpack": "webpack --mode production",

--- a/src/__tests__/FusionAuthProvider.test.tsx
+++ b/src/__tests__/FusionAuthProvider.test.tsx
@@ -5,6 +5,7 @@ import {
     useFusionAuth,
 } from '../providers/FusionAuthProvider';
 import { mockCrypto } from './mocks/mockCrypto';
+import { mockFetchJson } from './mocks/mockFetchJson';
 import { TEST_CONFIG } from './mocks/testConfig';
 
 let location: Location;
@@ -45,6 +46,7 @@ describe('FusionAuthProvider', () => {
     });
 
     test('Logout function will navigate to the correct url', async () => {
+        mockFetchJson({});
         const mockedLocation = {
             ...location,
             assign: jest.fn(),

--- a/src/providers/FusionAuthProvider.tsx
+++ b/src/providers/FusionAuthProvider.tsx
@@ -102,7 +102,13 @@ export const FusionAuthProvider: React.FC<FusionAuthConfig> = props => {
                 window.location.assign(fullUrl);
             },
         );
-    }, [generateUrl, props.clientID, props.idTokenHint, props.redirectUri]);
+    }, [
+        generateUrl,
+        props.clientID,
+        props.idTokenHint,
+        props.redirectUri,
+        props.serverUrl,
+    ]);
 
     const register = useCallback(
         async (state = '') => {

--- a/src/providers/FusionAuthProvider.tsx
+++ b/src/providers/FusionAuthProvider.tsx
@@ -91,13 +91,17 @@ export const FusionAuthProvider: React.FC<FusionAuthConfig> = props => {
         Cookies.remove('lastState');
         Cookies.remove('codeVerifier');
 
-        const queryParams = {
-            client_id: props.clientID,
-            post_logout_redirect_uri: props.redirectUri,
-            id_token_hint: props.idTokenHint ?? '',
-        };
-        const fullUrl = generateUrl(FunctionType.logout, queryParams);
-        window.location.assign(fullUrl);
+        fetch(`${props.serverUrl}/logout`, { credentials: 'include' }).then(
+            () => {
+                const queryParams = {
+                    client_id: props.clientID,
+                    post_logout_redirect_uri: props.redirectUri,
+                    id_token_hint: props.idTokenHint ?? '',
+                };
+                const fullUrl = generateUrl(FunctionType.logout, queryParams);
+                window.location.assign(fullUrl);
+            },
+        );
     }, [generateUrl, props.clientID, props.idTokenHint, props.redirectUri]);
 
     const register = useCallback(


### PR DESCRIPTION
**Issue**:
https://github.com/FusionAuth/fusionauth-react-sdk/issues/27
https://github.com/FusionAuth/fusionauth-issues/issues/2023

**Summary**:
When the user logs out, the access_token and refresh_tokens should be cleared.  Otherwise, subsequent requests made by that browser session will send the access_token.  This could be used to continue to provide access to apis until the jwt expires.

**Solution**:
Call /logout route that clears the access_token and refresh_token cookies.

**Linked PR**:
https://github.com/FusionAuth/fusionauth-example-react-sdk/pull/16

**Reviewer Notes**
Implementation is slightly different than https://github.com/FusionAuth/fusionauth-issues/issues/2023 suggests for simplicity.  Hitting the Logout button first makes a call to /logout endpoint before redirecting to /oauth2/logout.

#### Pre-Merge Checklist (if applicable)

-   [X] Unit and Feature tests have been added/updated for logic changes, or there is a justifiable reason for not doing so.
