### PR TITLE
Renamed and scoped npm module to @fusionauth/react-sdk

### DIFF
--- a/CHANGES.adoc
+++ b/CHANGES.adoc
@@ -1,8 +1,8 @@
 fusionauth-react-sdk Changes
 
-Changes in 0.22.2
+Changes in 0.23.0
 
- * *Breaking change* Module is now scoped under `@fusionauth`.  Users will need to update `package.json` and imports.
+ * *Breaking change* Module is now scoped and renamed to `@fusionauth/react-sdk`.  Users will need to update `package.json` and imports.
 
 Changes in 0.22.1
 

--- a/CHANGES.adoc
+++ b/CHANGES.adoc
@@ -1,0 +1,9 @@
+fusionauth-react-sdk Changes
+
+Changes in 0.22.2
+
+ * *Breaking change* Module is now scoped under `@fusionauth`.  Users will need to update `package.json` and imports.
+
+Changes in 0.22.1
+
+ * *Breaking change* Logout calls new server `/logout` endpoint before redirecting to `/oauth2/logout`

--- a/README.adoc
+++ b/README.adoc
@@ -55,14 +55,14 @@ NPM:
 
 [source,bash]
 ----
-npm install fusionauth-react-sdk
+npm install @fusionauth/fusionauth-react-sdk
 ----
 
 Yarn:
 
 [source,bash]
 ----
-yarn add fusionauth-react-sdk
+yarn add @fusionauth/fusionauth-react-sdk
 ----
 
 === Configuring Provider
@@ -73,7 +73,7 @@ To configure the SDK, wrap your app with `FusionAuthProvider`:
 ----
 import React from 'react';
 import { createRoot } from 'react-dom/client';
-import { FusionAuthProvider } from 'fusionauth-react-sdk';
+import { FusionAuthProvider } from '@fusionauth/fusionauth-react-sdk';
 import App from './App';
 
 const container = document.getElementById('root');
@@ -119,6 +119,15 @@ this object.
 https://github.com/FusionAuth/fusionauth-example-react-sdk/blob/main/server/routes/token-exchange.js[Example
 implementation]
 
+==== `GET /logout`
+
+This endpoint must:
+
+. Clear the `access_token` and `refresh_token` secure, HTTP-only cookies.
+
+https://github.com/FusionAuth/fusionauth-example-react-sdk/blob/main/server/routes/logout.js[Example
+implementation]
+
 ==== `POST /jwt-refresh` (optional)
 
 This endpoint is necessary if you wish to use refresh tokens. This
@@ -147,7 +156,7 @@ import {
     FusionAuthLoginButton,
     FusionAuthLogoutButton,
     FusionAuthRegisterButton
-} from 'fusionauth-react-sdk';
+} from '@fusionauth/fusionauth-react-sdk';
 
 export const LoginPage = () => (
     <>
@@ -182,7 +191,7 @@ https://github.com/FusionAuth/fusionauth-react-sdk/blob/main/docs/context.md#fus
 [source,tsx]
 ----
 import React from 'react';
-import { useFusionAuth } from 'fusionauth-react-sdk';
+import { useFusionAuth } from '@fusionauth/fusionauth-react-sdk';
 
 const App = () => {
     const { login, logout, register, isAuthenticated } = useFusionAuth();
@@ -217,7 +226,7 @@ both functional and class components:
 [source,tsx]
 ----
 import React from 'react';
-import { withFusionAuth, WithFusionAuthProps } from 'fusionauth-react-sdk';
+import { withFusionAuth, WithFusionAuthProps } from '@fusionauth/fusionauth-react-sdk';
 
 const LogoutButton: React.FC<WithFusionAuthProps> = props => {
     const { logout } = props.fusionAuth;
@@ -233,7 +242,7 @@ export default withFusionAuth(LogoutButton);
 [source,tsx]
 ----
 import React, { Component } from 'react';
-import { withFusionAuth, WithFusionAuthProps } from 'fusionauth-react-sdk';
+import { withFusionAuth, WithFusionAuthProps } from '@fusionauth/fusionauth-react-sdk';
 
 class LogoutButton extends Component<WithFusionAuthProps> {
     render() {
@@ -267,7 +276,7 @@ used to ensure the user has a specific role.
 
 [source,tsx]
 ----
-import { RequireAuth, useFusionAuth } from 'fusionauth-react-sdk';
+import { RequireAuth, useFusionAuth } from '@fusionauth/fusionauth-react-sdk';
 
 const UserNameDisplay = () => {
     const { user } = useFusionAuth();

--- a/README.adoc
+++ b/README.adoc
@@ -55,14 +55,14 @@ NPM:
 
 [source,bash]
 ----
-npm install @fusionauth/fusionauth-react-sdk
+npm install @fusionauth/react-sdk
 ----
 
 Yarn:
 
 [source,bash]
 ----
-yarn add @fusionauth/fusionauth-react-sdk
+yarn add @fusionauth/react-sdk
 ----
 
 === Configuring Provider
@@ -73,7 +73,7 @@ To configure the SDK, wrap your app with `FusionAuthProvider`:
 ----
 import React from 'react';
 import { createRoot } from 'react-dom/client';
-import { FusionAuthProvider } from '@fusionauth/fusionauth-react-sdk';
+import { FusionAuthProvider } from '@fusionauth/react-sdk';
 import App from './App';
 
 const container = document.getElementById('root');
@@ -156,7 +156,7 @@ import {
     FusionAuthLoginButton,
     FusionAuthLogoutButton,
     FusionAuthRegisterButton
-} from '@fusionauth/fusionauth-react-sdk';
+} from '@fusionauth/react-sdk';
 
 export const LoginPage = () => (
     <>
@@ -186,12 +186,12 @@ Alternatively, you may interact with the SDK programmatically using the
 
 Use the `useFusionAuth` hook with your functional components to get
 access to the properties exposed by
-https://github.com/FusionAuth/fusionauth-react-sdk/blob/main/docs/context.md#fusionauthcontext[FusionAuthContext]:
+https://github.com/FusionAuth/react-sdk/blob/main/docs/context.md#fusionauthcontext[FusionAuthContext]:
 
 [source,tsx]
 ----
 import React from 'react';
-import { useFusionAuth } from '@fusionauth/fusionauth-react-sdk';
+import { useFusionAuth } from '@fusionauth/react-sdk';
 
 const App = () => {
     const { login, logout, register, isAuthenticated } = useFusionAuth();
@@ -211,7 +211,7 @@ const App = () => {
 ----
 
 See
-https://github.com/FusionAuth/fusionauth-react-sdk/blob/main/docs/functions.md#usefusionauth[useFusionAuth]
+https://github.com/FusionAuth/react-sdk/blob/main/docs/functions.md#usefusionauth[useFusionAuth]
 for more details.
 
 ==== withFusionAuth
@@ -226,7 +226,7 @@ both functional and class components:
 [source,tsx]
 ----
 import React from 'react';
-import { withFusionAuth, WithFusionAuthProps } from '@fusionauth/fusionauth-react-sdk';
+import { withFusionAuth, WithFusionAuthProps } from '@fusionauth/react-sdk';
 
 const LogoutButton: React.FC<WithFusionAuthProps> = props => {
     const { logout } = props.fusionAuth;
@@ -242,7 +242,7 @@ export default withFusionAuth(LogoutButton);
 [source,tsx]
 ----
 import React, { Component } from 'react';
-import { withFusionAuth, WithFusionAuthProps } from '@fusionauth/fusionauth-react-sdk';
+import { withFusionAuth, WithFusionAuthProps } from '@fusionauth/react-sdk';
 
 class LogoutButton extends Component<WithFusionAuthProps> {
     render() {
@@ -255,7 +255,7 @@ export default withFusionAuth(LogoutButton);
 ----
 
 See
-https://github.com/FusionAuth/fusionauth-react-sdk/blob/main/docs/functions.md#withfusionauth[withFusionAuth]
+https://github.com/FusionAuth/react-sdk/blob/main/docs/functions.md#withfusionauth[withFusionAuth]
 for more details.
 
 ==== State parameter
@@ -276,7 +276,7 @@ used to ensure the user has a specific role.
 
 [source,tsx]
 ----
-import { RequireAuth, useFusionAuth } from '@fusionauth/fusionauth-react-sdk';
+import { RequireAuth, useFusionAuth } from '@fusionauth/react-sdk';
 
 const UserNameDisplay = () => {
     const { user } = useFusionAuth();
@@ -321,7 +321,7 @@ exchange.
 
 == Documentation
 
-https://github.com/FusionAuth/fusionauth-react-sdk/blob/main/docs/documentation.md[Full
+https://github.com/FusionAuth/react-sdk/blob/main/docs/documentation.md[Full
 library documentation]
 
 //end::forDocSite[]

--- a/README.adoc
+++ b/README.adoc
@@ -186,7 +186,7 @@ Alternatively, you may interact with the SDK programmatically using the
 
 Use the `useFusionAuth` hook with your functional components to get
 access to the properties exposed by
-https://github.com/FusionAuth/react-sdk/blob/main/docs/context.md#fusionauthcontext[FusionAuthContext]:
+https://github.com/FusionAuth/fusionauth-react-sdk/blob/main/docs/context.md#fusionauthcontext[FusionAuthContext]:
 
 [source,tsx]
 ----
@@ -211,7 +211,7 @@ const App = () => {
 ----
 
 See
-https://github.com/FusionAuth/react-sdk/blob/main/docs/functions.md#usefusionauth[useFusionAuth]
+https://github.com/FusionAuth/fusionauth-react-sdk/blob/main/docs/functions.md#usefusionauth[useFusionAuth]
 for more details.
 
 ==== withFusionAuth
@@ -255,7 +255,7 @@ export default withFusionAuth(LogoutButton);
 ----
 
 See
-https://github.com/FusionAuth/react-sdk/blob/main/docs/functions.md#withfusionauth[withFusionAuth]
+https://github.com/FusionAuth/fusionauth-react-sdk/blob/main/docs/functions.md#withfusionauth[withFusionAuth]
 for more details.
 
 ==== State parameter
@@ -321,7 +321,7 @@ exchange.
 
 == Documentation
 
-https://github.com/FusionAuth/react-sdk/blob/main/docs/documentation.md[Full
+https://github.com/FusionAuth/fusionauth-react-sdk/blob/main/docs/documentation.md[Full
 library documentation]
 
 //end::forDocSite[]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "fusionauth-react-sdk",
-  "version": "0.22.1",
+  "name": "@fusionauth/fusionauth-react-sdk",
+  "version": "0.22.2",
   "description": "FusionAuth solves the problem of building essential security without adding risk or distracting from your primary application",
   "scripts": {
     "webpack": "webpack --mode production",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@fusionauth/fusionauth-react-sdk",
-  "version": "0.22.2",
+  "name": "@fusionauth/react-sdk",
+  "version": "0.23.0",
   "description": "FusionAuth solves the problem of building essential security without adding risk or distracting from your primary application",
   "scripts": {
     "webpack": "webpack --mode production",


### PR DESCRIPTION
## What is this PR and why do we need it?

Now scoping npm module under `@fusionauth` for better maintainability.


#### Pre-Merge Checklist (if applicable)

-   [x] Unit and Feature tests have been added/updated for logic changes, or there is a justifiable reason for not doing so.
