### PR TITLE
remove content-type header for post with empty body

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fusionauth/react-sdk",
-  "version": "0.23.1",
+  "version": "0.23.2",
   "description": "FusionAuth solves the problem of building essential security without adding risk or distracting from your primary application",
   "scripts": {
     "webpack": "webpack --mode production",

--- a/src/providers/FusionAuthProvider.tsx
+++ b/src/providers/FusionAuthProvider.tsx
@@ -141,9 +141,6 @@ export const FusionAuthProvider: React.FC<FusionAuthConfig> = props => {
     const refreshToken = useCallback(async () => {
         await fetch(`${props.serverUrl}/jwt-refresh`, {
             method: 'POST',
-            headers: {
-                'content-type': 'application/json',
-            },
             credentials: 'include',
         });
     }, [props.serverUrl]);


### PR DESCRIPTION
## What is this PR and why do we need it?

Removes `content-type` header for http post with empty body.  Setting `application/json` could cause the server backend to fail the request if it tried to parse json from the body.
https://github.com/FusionAuth/fusionauth-react-sdk/issues/44

#### Pre-Merge Checklist (if applicable)

Ran change locally against Node server.