### PR TITLE
Allow withRole in RequireAuth to be an array of strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -334,7 +334,8 @@ be returned to that location after a successful authentication.
 
 The `RequireAuth` component can be used to protect information from
 unauthorized users. It takes an optional prop `withRole` that can be
-used to ensure the user has a specific role.
+used to ensure the user has a specific role. If an array of roles is
+passed, the user must have at least one of the roles to be authorized.
 
 ```react
 import { RequireAuth, useFusionAuth } from '@fusionauth/react-sdk';

--- a/src/__tests__/RequireAuth.test.tsx
+++ b/src/__tests__/RequireAuth.test.tsx
@@ -1,7 +1,11 @@
 import React from 'react';
 import { screen, render, waitFor, act } from '@testing-library/react';
 import { RequireAuth } from '../components/RequireAuth';
-import { FusionAuthProvider } from '../providers/FusionAuthProvider';
+import {
+    FusionAuthContext,
+    FusionAuthProvider,
+    IFusionAuthContext,
+} from '../providers/FusionAuthProvider';
 import { FusionAuthLogoutButton } from '../components/FusionAuthLogoutButton';
 import {
     TEST_REDIRECT_URL,
@@ -57,6 +61,12 @@ describe('RequireAuth Component', () => {
         });
 
         // expect(await screen.queryByText('Logout')).toBeNull();
+        expect(await screen.findByText('Logout')).toBeInTheDocument();
+    });
+
+    test('RequireAuth Component renders children when user is present with one of the roles present', async () => {
+        renderWithContext(['admin', 'super-admin'], ['admin']);
+
         expect(await screen.findByText('Logout')).toBeInTheDocument();
     });
 
@@ -129,5 +139,29 @@ const renderProvider = (role?: string) => {
                 </RequireAuth>
             </FusionAuthProvider>,
         ),
+    );
+};
+
+const renderWithContext = (
+    providerRoles: string | string[],
+    role?: string | string[],
+) => {
+    // We mock the fusion auth context to return a user with the admin role
+    const context: IFusionAuthContext = {
+        login: () => Promise.resolve(),
+        logout: () => Promise.resolve(),
+        register: () => Promise.resolve(),
+        user: { roles: providerRoles },
+        isLoading: false,
+        isAuthenticated: true,
+        refreshToken: () => Promise.resolve(),
+    };
+
+    return render(
+        <FusionAuthContext.Provider value={context}>
+            <RequireAuth withRole={role}>
+                <FusionAuthLogoutButton />
+            </RequireAuth>
+        </FusionAuthContext.Provider>,
     );
 };

--- a/src/components/RequireAuth.tsx
+++ b/src/components/RequireAuth.tsx
@@ -2,15 +2,21 @@ import React, { FC, PropsWithChildren } from 'react';
 import { useFusionAuth } from '../providers/FusionAuthProvider';
 
 interface Props extends PropsWithChildren {
-    withRole?: string;
+    withRole?: string | string[];
 }
 
 export const RequireAuth: FC<Props> = ({ withRole, children }) => {
     const { user, isAuthenticated } = useFusionAuth();
 
-    const isAuthorized = withRole
-        ? isAuthenticated && user?.roles?.includes(withRole)
-        : isAuthenticated;
+    // Check if the user has the required role
+    // withRole can be a string or an array of strings
+    const hasRole = withRole
+        ? ([] as string[])
+              .concat(withRole)
+              .some(role => user?.roles?.includes(role))
+        : true;
+
+    const isAuthorized = isAuthenticated && hasRole;
 
     return <>{isAuthorized && children}</>;
 };


### PR DESCRIPTION
## What is this PR and why do we need it?

Extend RequireAuth to allow multiple roles in the `withRole` parameter.

I was unable to add a test with the mocked up fetch call, but I added it with a static context provider. Hope that is sufficient.

#### Pre-Merge Checklist (if applicable)

-   [x] Unit and Feature tests have been added/updated for logic changes, or there is a justifiable reason for not doing so.

Closes #50 