### PR TITLE
refreshToken() is not properly checking the expiration time preventing early calls

### DIFF
--- a/src/providers/FusionAuthProvider.tsx
+++ b/src/providers/FusionAuthProvider.tsx
@@ -168,7 +168,7 @@ export const FusionAuthProvider: React.FC<FusionAuthConfig> = props => {
             props.accessTokenExpireWindow ?? DEFAULT_ACCESS_TOKEN_EXPIRE_WINDOW;
         if (
             accessTokenExpires === undefined ||
-            Number(accessTokenExpires) < Date.now() + timeWindow
+            Number(accessTokenExpires) * 1000 < Date.now() + timeWindow
         ) {
             await fetch(
                 generateServerUrl(


### PR DESCRIPTION
## What is this PR and why do we need it?

The expiration time cookie is set in a timestamp (seconds) but the calculations used in `refreshToken` are in milliseconds. Without converting the `app.at_exp` cookie to ms, the refreshToken is not being guarded against early calls as the code intends. 

#### Pre-Merge Checklist (if applicable)

-   [ ] Unit and Feature tests have been added/updated for logic changes, or there is a justifiable reason for not doing so.
