### PR TITLE
Match logout button style to other buttons

### DIFF
--- a/src/components/FusionAuthLogoutButton.tsx
+++ b/src/components/FusionAuthLogoutButton.tsx
@@ -13,7 +13,7 @@ export const FusionAuthLogoutButton: FC<Props> = ({ text, className }) => {
 
     return (
         <button
-            className={classNames(styles.fusionAuthLogoutButton, className)}
+            className={classNames(styles.fusionAuthButton, className)}
             type="button"
             onClick={() => logout()}
         >

--- a/src/styles/button.module.scss
+++ b/src/styles/button.module.scss
@@ -16,17 +16,3 @@
     cursor: pointer;
   }
 }
-
-.fusionAuthLogoutButton {
-  padding: 7px 13px;
-  border-radius: 3px;
-  display: block;
-  border: solid 1px #083b94;
-  font-family: var(--font-stack);
-  font-size: 12px;
-  text-align: center;
-  color: #083b94;
-  &:hover {
-    cursor: pointer;
-  }
-}


### PR DESCRIPTION
## What is this PR and why do we need it?

Addressing issue #30. `FusionAuthLogoutButton` uses a different classname than the other buttons. This consolidates the button styles so they have the same class name.

#### Pre-Merge Checklist (if applicable)

-   [x] Unit and Feature tests have been added/updated for logic changes, or there is a justifiable reason for not doing so.
