### PR TITLE
set `isAuthenticated` when `user` is set

### DIFF
--- a/src/providers/FusionAuthProvider.tsx
+++ b/src/providers/FusionAuthProvider.tsx
@@ -214,13 +214,14 @@ export const FusionAuthProvider: React.FC<FusionAuthConfig> = props => {
         setIsLoading(false);
     }, [generateServerUrl, mePath, onRedirectSuccess, onRedirectFail]);
 
-    const didSetUser = useRef(false);
+    const didAttemptToSetUser = useRef(false);
     useEffect(() => {
-        if (isLoading || isAuthenticated || didSetUser.current) {
+        if (isLoading || isAuthenticated || didAttemptToSetUser.current) {
             return;
         }
 
-        didSetUser.current = true;
+        // ensures this effect does not run multiple times if we fail to set the user
+        didAttemptToSetUser.current = true;
 
         const userCookie = Cookies.get('user');
         if (userCookie) {
@@ -229,6 +230,8 @@ export const FusionAuthProvider: React.FC<FusionAuthConfig> = props => {
         }
 
         const hasIdToken = Boolean(Cookies.get('app.idt'));
+        // the presence of app.idt indicates that this is a redirect from login
+        // which means we want to fetch the user
         if (hasIdToken) {
             fetchUserFromServer();
         }


### PR DESCRIPTION
## What is this PR and why do we need it?
Addresses issue #22 (and inadvertantly #57)
There are some instances where `user` and `isAuthenticated` are not set at the same time, which leads to cases where `user` is set, yet `isAuthenticated` is false. This PR is to ensure that `isAuthenticated` is a function of `user` being set.

Users of the SDK should be able to expect:
- `isAuthenticated` to be `true` when `user` is set
- `isAuthenticated` to be `false` when `user` is not set i.e. `{}`

Case in point 👉 issue #57.

**Changes**
- use `useMemo` with `user` as a dependency to set `isAuthenticated`.
- Don't use cookies to set `isAuthenticated`

#### Pre-Merge Checklist (if applicable)

-   [x] Unit and Feature tests have been added/updated for logic changes, or there is a justifiable reason for not doing so.
