### PR TITLE
adds source maps

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -13,6 +13,7 @@ module.exports = {
             react: path.resolve('./node_modules/react'),
         },
     },
+    devtool: 'source-map',
     externals: [nodeExternals()],
     output: {
         filename: 'index.js',


### PR DESCRIPTION
## What is this PR and why do we need it?
This is to ensure source maps are shipped with the package, so developers can debug more easily. This can be accomplished with [webpack devtool](https://webpack.js.org/configuration/devtool/).

Requested by issue #49

If you boot up the example/quickstart app you can use the browser dev tools to observe that the SDK source code is minified and not human-readable. This webpack configuration will add source maps to the `dist` folder of the SDK.

As a test, with this branch you should be able to view the SDK reconstructed source code with browser dev tools.

#### Pre-Merge Checklist (if applicable)

-   [x] Unit and Feature tests have been added/updated for logic changes, or there is a justifiable reason for not doing so.
