### PR TITLE
removes async definitions for non-async functions

### DIFF
--- a/src/__tests__/FusionAuthProvider.test.tsx
+++ b/src/__tests__/FusionAuthProvider.test.tsx
@@ -22,7 +22,7 @@ describe('FusionAuthProvider', () => {
         jest.clearAllMocks();
     });
 
-    test('Login function will navigate to the correct url', async () => {
+    test('Login function will navigate to the correct url', () => {
         const mockedLocation = {
             ...location,
             assign: jest.fn(),
@@ -36,13 +36,11 @@ describe('FusionAuthProvider', () => {
             wrapper,
         });
 
-        await waitFor(() => result.current.login('state'));
+        result.current.login('state');
 
         const expectedUrl =
             'http://localhost:9000/app/login?client_id=85a03867-dccf-4882-adde-1a79aeec50df&scope=openid+offline_access&redirect_uri=http%3A%2F%2Flocalhost&state=00000000000000000000000000000000000000000000000000000000%3Astate';
-        await waitFor(() =>
-            expect(mockedLocation.assign).toBeCalledWith(expectedUrl),
-        );
+        expect(mockedLocation.assign).toHaveBeenCalledWith(expectedUrl);
     });
 
     test('User set to the value stored in the cookie', () => {
@@ -129,7 +127,7 @@ describe('FusionAuthProvider', () => {
         expect(result.current.isAuthenticated).toEqual(false);
     });
 
-    test('Logout function will navigate to the correct url', async () => {
+    test('Logout function will navigate to the correct url', () => {
         mockFetchJson({});
         const mockedLocation = {
             ...location,
@@ -144,17 +142,15 @@ describe('FusionAuthProvider', () => {
             wrapper,
         });
 
-        await result.current.logout();
+        result.current.logout();
 
         const expectedUrl =
             'http://localhost:9000/app/logout?client_id=85a03867-dccf-4882-adde-1a79aeec50df&post_logout_redirect_uri=http%3A%2F%2Flocalhost';
 
-        await waitFor(() =>
-            expect(mockedLocation.assign).toBeCalledWith(expectedUrl),
-        );
+        expect(mockedLocation.assign).toHaveBeenCalledWith(expectedUrl);
     });
 
-    test('Register function will navigate to the correct url', async () => {
+    test('Register function will navigate to the correct url', () => {
         const mockedLocation = {
             ...location,
             assign: jest.fn(),
@@ -168,16 +164,14 @@ describe('FusionAuthProvider', () => {
             wrapper,
         });
 
-        await waitFor(() => result.current.register('state'));
+        result.current.register('state');
 
         const expectedUrl =
             'http://localhost:9000/app/register?client_id=85a03867-dccf-4882-adde-1a79aeec50df&redirect_uri=http%3A%2F%2Flocalhost&scope=openid+offline_access&state=00000000000000000000000000000000000000000000000000000000%3Astate';
-        await waitFor(() =>
-            expect(mockedLocation.assign).toBeCalledWith(expectedUrl),
-        );
+        expect(mockedLocation.assign).toHaveBeenCalledWith(expectedUrl);
     });
 
-    test.only('Will invoke the onRedirectFail callback only once', async () => {
+    test('Will invoke the onRedirectFail callback only once', async () => {
         Object.defineProperty(document, 'cookie', {
             writable: true,
             // lastState should ensure redirect handlers are called

--- a/src/providers/FusionAuthProvider.tsx
+++ b/src/providers/FusionAuthProvider.tsx
@@ -14,9 +14,9 @@ const DEFAULT_SCOPE = 'openid offline_access';
 const DEFAULT_ACCESS_TOKEN_EXPIRE_WINDOW = 30000;
 
 export interface IFusionAuthContext {
-    login: (state?: string) => Promise<void>;
-    logout: () => Promise<void>;
-    register: (state?: string) => Promise<void>;
+    login: (state?: string) => void;
+    logout: () => void;
+    register: (state?: string) => void;
     user: Record<string, any>;
     isLoading: boolean;
     isAuthenticated: boolean;
@@ -24,9 +24,9 @@ export interface IFusionAuthContext {
 }
 
 export const FusionAuthContext = React.createContext<IFusionAuthContext>({
-    login: () => Promise.resolve(),
-    logout: () => Promise.resolve(),
-    register: () => Promise.resolve(),
+    login: () => {},
+    logout: () => {},
+    register: () => {},
     user: {},
     isLoading: false,
     isAuthenticated: false,
@@ -77,7 +77,7 @@ export const FusionAuthProvider: React.FC<FusionAuthConfig> = props => {
     );
 
     const login = useCallback(
-        async (state = '') => {
+        (state = '') => {
             const stateParam = setUpRedirect(state);
             const fullUrl = generateServerUrl(
                 ServerFunctionType.login,
@@ -100,7 +100,7 @@ export const FusionAuthProvider: React.FC<FusionAuthConfig> = props => {
         ],
     );
 
-    const logout = useCallback(async () => {
+    const logout = useCallback(() => {
         // Clear cookies
         Cookies.remove('user');
         Cookies.remove('lastState');
@@ -124,7 +124,7 @@ export const FusionAuthProvider: React.FC<FusionAuthConfig> = props => {
     ]);
 
     const register = useCallback(
-        async (state = '') => {
+        (state = '') => {
             const stateParam = setUpRedirect(state);
             const fullUrl = generateServerUrl(
                 ServerFunctionType.register,


### PR DESCRIPTION
## What is this PR and why do we need it?
Fixes the issue described by #68
This is to remove `async` from definitions of non-async functions (the `login`, `logout`, and `register` functions)

#### Pre-Merge Checklist (if applicable)
-   [x] Unit and Feature tests have been added/updated for logic changes, or there is a justifiable reason for not doing so.
