### PR TITLE
adds option to set custom at_exp cookie name

### DIFF
--- a/src/providers/FusionAuthProvider.tsx
+++ b/src/providers/FusionAuthProvider.tsx
@@ -61,10 +61,17 @@ export const FusionAuthProvider: React.FC<FusionAuthConfig> = props => {
     const [user, setUser] = useState<User>({});
     const isAuthenticated = useMemo(() => Object.keys(user).length > 0, [user]);
 
-    const accessTokenExpireCookieName = useMemo(
-        () => props.accessTokenExpireCookieName ?? 'app.at_exp',
-        [props.accessTokenExpireCookieName],
-    );
+    const accessTokenExpireCookieName = useMemo(() => {
+        if (props.accessTokenExpireCookieName?.length) {
+            return props.accessTokenExpireCookieName;
+        }
+
+        console.warn(
+            'Cannot set access token cookie name to empty string. Using default value.',
+        );
+
+        return 'app.at_exp';
+    }, [props.accessTokenExpireCookieName]);
 
     const generateServerUrl = useCallback(
         (

--- a/src/providers/FusionAuthProvider.tsx
+++ b/src/providers/FusionAuthProvider.tsx
@@ -44,6 +44,7 @@ export interface FusionAuthConfig extends PropsWithChildren {
     onRedirectFail?: RedirectFail;
     scope?: string;
     accessTokenExpireWindow?: number;
+    accessTokenExpireCookieName?: string;
     loginPath?: string;
     logoutPath?: string;
     registerPath?: string;
@@ -59,6 +60,11 @@ export const FusionAuthProvider: React.FC<FusionAuthConfig> = props => {
     type User = Record<string, any>;
     const [user, setUser] = useState<User>({});
     const isAuthenticated = useMemo(() => Object.keys(user).length > 0, [user]);
+
+    const accessTokenExpireCookieName = useMemo(
+        () => props.accessTokenExpireCookieName ?? 'app.at_exp',
+        [props.accessTokenExpireCookieName],
+    );
 
     const generateServerUrl = useCallback(
         (
@@ -148,7 +154,7 @@ export const FusionAuthProvider: React.FC<FusionAuthConfig> = props => {
     );
 
     const refreshToken = useCallback(async () => {
-        const accessTokenExpires = Cookies.get('app.at_exp');
+        const accessTokenExpires = Cookies.get(accessTokenExpireCookieName);
         const timeWindow =
             props.accessTokenExpireWindow ?? DEFAULT_ACCESS_TOKEN_EXPIRE_WINDOW;
         const fallbackTokenRefreshPath = `/app/refresh/${props.clientID}`;
@@ -173,6 +179,7 @@ export const FusionAuthProvider: React.FC<FusionAuthConfig> = props => {
             );
         }
     }, [
+        accessTokenExpireCookieName,
         props.accessTokenExpireWindow,
         props.tokenRefreshPath,
         props.clientID,


### PR DESCRIPTION
## What is this PR and why do we need it?
A small enhancement described by issue #57. Users of the SDK should be able to set a custom cookie name for the access token expiration cookie (defaults to `app.at_exp` -- which is what is used by the FA hosted server)

#### Pre-Merge Checklist (if applicable)
-   [x] Unit and Feature tests have been added/updated for logic changes, or there is a justifiable reason for not doing so.
