### PR TITLE
Adding archival note to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+**This repo is out of date and is archived. `@fusionauth/react-sdk` is currently maintained at https://github.com/FusionAuth/fusionauth-javascript-sdk/tree/main/packages/sdk-react.**
+
 An SDK for using FusionAuth in React applications.
 
 # Table of Contents
@@ -19,8 +21,6 @@ An SDK for using FusionAuth in React applications.
     -   [Protecting content](#protecting-content)
 
     -   [Known issues](#known-issues)
-
--   [Example App](#example-app)
 
 -   [Quickstart](#quickstart)
 


### PR DESCRIPTION
## What is this PR and why do we need it?
#99 - Adding an archival note to the README. Once this PR is merged, this repo is ready to become archived, and we will be maintaining `@fusionauth/react-sdk` from the [sdk-react package within our monorepo](https://github.com/FusionAuth/fusionauth-javascript-sdk/tree/main/packages/sdk-react) going forward.

#### Pre-Merge Checklist (if applicable)
-   [x] Unit and Feature tests have been added/updated for logic changes, or there is a justifiable reason for not doing so.
